### PR TITLE
add missing include (cstring)

### DIFF
--- a/lib/Network.cpp
+++ b/lib/Network.cpp
@@ -17,6 +17,7 @@
 #include "countly/Network.h"
 #include "countly/Version.h"
 
+#include <cstring>
 #include <sstream>
 #include <iomanip>
 #include <unistd.h>


### PR DESCRIPTION
Fix:
countly-cpp/lib/Network.cpp: In member function ‘bool countly::Network::get(std::__cxx11::string, std::__cxx11::string)’:
countly-cpp/lib/Network.cpp:103:27: error: ‘memset’ was not declared in this scope
   memset(buffer, 0x00, 512);
                           ^
countly-cpp/lib/Network.cpp:105:67: error: ‘memcmp’ was not declared in this scope
   success = (size >= 15) && (!memcmp(buffer, "HTTP/1.1 200 OK", 15));
                                                                   ^
countly-cpp/lib/Network.cpp: In member function ‘int countly::Network::_httpConnect(std::__cxx11::string)’:
countly-cpp/lib/Network.cpp:115:52: error: ‘memset’ was not declared in this scope
   memset((char *) &scktAddr, 0x00, sizeof(scktAddr));
